### PR TITLE
Fix oversensitive PR review trigger

### DIFF
--- a/src/services/githubService.js
+++ b/src/services/githubService.js
@@ -383,7 +383,7 @@ async function getCombinedStatus({ repoOwner, repoName, ref }) {
     const response = await axios.get(url, {
       headers: {
         Accept: 'application/vnd.github.v3+json',
-        Authorization: `token ${githubToken}`,
+        Authorization: `token ${process.env.GITHUB_TOKEN}`,
         'User-Agent': 'Claude-GitHub-Webhook'
       }
     });


### PR DESCRIPTION
## Summary
- Fix PR review trigger firing on every individual check_suite completion
- Add GitHub Combined Status API validation to ensure ALL checks pass before reviewing
- Prevent 30+ duplicate reviews when multiple CI checks are running

## Changes
- Added `getCombinedStatus()` function to query GitHub's Combined Status API  
- Modified check_suite webhook handler to validate `combinedStatus.state === 'success'`
- Enhanced logging to show combined status information for debugging
- Maintains immediate webhook response while adding proper validation

## Test plan
- [x] Lint and type checks pass
- [x] All unit tests pass including new Combined Status API mocking
- [x] E2E container tests verify integration works
- [ ] Deploy to staging and test with actual PRs having multiple CI checks
- [ ] Verify only one review is triggered when all checks complete

🤖 Generated with [Claude Code](https://claude.ai/code)