### PR TITLE
Fix TruffleHog failing on scheduled runs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -47,8 +47,8 @@ jobs:
       uses: trufflesecurity/trufflehog@main
       with:
         path: ./
-        base: main
-        head: HEAD
+        base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+        head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
         extra_args: --debug --only-verified
 
   codeql:


### PR DESCRIPTION
## Summary
- Fix TruffleHog security scan failing with "BASE and HEAD commits are the same" error on scheduled runs
- Only set base/head parameters for pull requests where they represent different commits
- For scheduled runs and pushes to main, allow TruffleHog to scan the entire repository

## Problem
TruffleHog was configured with static `base: main` and `head: HEAD` parameters, which are the same commit on scheduled runs and pushes to main branch, causing the scan to fail.

## Solution
Modified the workflow to conditionally set base/head only for pull requests:
```yaml
base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
```

This ensures:
- **Pull requests**: Scan only the changes between base and head commits
- **Scheduled/push events**: Scan the entire repository (no base/head specified)

## Test plan
- [ ] Verify workflow passes on this PR (pull request event)
- [ ] After merge, verify scheduled runs complete successfully
- [ ] Verify push to main events complete successfully

🤖 Generated with [Claude Code](https://claude.ai/code)