### PR TITLE
Fix Docker environment variable passing for long commands

### DIFF
--- a/test/unit/services/claudeService.test.js
+++ b/test/unit/services/claudeService.test.js
@@ -50,7 +50,6 @@ jest.mock('../../../src/utils/secureCredentials', () => ({
 
 // Now require the module under test
 const { execFileSync } = require('child_process');
-const { writeFileSync } = require('fs');
 const { promisify } = require('util');
 const { sanitizeBotMentions } = require('../../../src/utils/sanitize');
 const claudeService = require('../../../src/services/claudeService');


### PR DESCRIPTION
## Summary
- Fixed broken Docker command execution that was causing "Claude Code container is ready" responses
- Removed invalid `@file` syntax that Docker doesn't support for environment variables
- Updated tests to match new implementation

## Problem
The webhook was responding with only "Claude Code container is ready. Provide a command to execute." because the COMMAND environment variable wasn't being passed correctly to the Docker container. The code was attempting to use `@filename` syntax which Docker doesn't support.

## Solution
- Pass environment variables directly to Docker using `-e KEY=value` format
- Removed temp file creation/cleanup logic that was no longer needed
- Updated unit test to verify long commands are handled properly

## Test plan
- [x] Unit tests pass
- [x] Linting passes (only pre-existing warnings)
- [ ] Test webhook with short command
- [ ] Test webhook with long command (>500 chars)
- [ ] Test auto-tagging on new issue
- [ ] Test @MCPClaude mention in issue comment

🤖 Generated with [Claude Code](https://claude.ai/code)