### PR TITLE
Fix linter warnings for no-sync rule

### DIFF
--- a/src/utils/awsCredentialProvider.js
+++ b/src/utils/awsCredentialProvider.js
@@ -150,7 +150,7 @@ class AWSCredentialProvider {
    * Get credentials from AWS profile
    */
   async getProfileCredentials(profileName) {
-    const fs = require('fs').promises;
+    const { promises: fs } = require('fs');
     const path = require('path');
     const os = require('os');
 

--- a/src/utils/awsCredentialProvider.js
+++ b/src/utils/awsCredentialProvider.js
@@ -150,7 +150,7 @@ class AWSCredentialProvider {
    * Get credentials from AWS profile
    */
   async getProfileCredentials(profileName) {
-    const fs = require('fs');
+    const fs = require('fs').promises;
     const path = require('path');
     const os = require('os');
 
@@ -159,8 +159,8 @@ class AWSCredentialProvider {
 
     try {
       // Read credentials file
-      const credentialsContent = fs.readFileSync(credentialsPath, 'utf8');
-      const configContent = fs.readFileSync(configPath, 'utf8');
+      const credentialsContent = await fs.readFile(credentialsPath, 'utf8');
+      const configContent = await fs.readFile(configPath, 'utf8');
 
       // Parse credentials for the specific profile
       const profileRegex = new RegExp(`\\[${profileName}\\]([^\\[]*)`);

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -6,7 +6,9 @@ const path = require('path');
 // Use home directory for logs to avoid permission issues
 const homeDir = process.env.HOME || '/tmp';
 const logsDir = path.join(homeDir, '.claude-webhook', 'logs');
+// eslint-disable-next-line no-sync
 if (!fs.existsSync(logsDir)) {
+  // eslint-disable-next-line no-sync
   fs.mkdirSync(logsDir, { recursive: true });
 }
 
@@ -111,17 +113,22 @@ if (isProduction) {
   // Check log file size and rotate if necessary
   try {
     const maxSize = 10 * 1024 * 1024; // 10MB
+    // eslint-disable-next-line no-sync
     if (fs.existsSync(logFileName)) {
+      // eslint-disable-next-line no-sync
       const stats = fs.statSync(logFileName);
       if (stats.size > maxSize) {
         // Simple rotation - keep up to 5 backup files
         for (let i = 4; i >= 0; i--) {
           const oldFile = `${logFileName}.${i}`;
           const newFile = `${logFileName}.${i + 1}`;
+          // eslint-disable-next-line no-sync
           if (fs.existsSync(oldFile)) {
+            // eslint-disable-next-line no-sync
             fs.renameSync(oldFile, newFile);
           }
         }
+        // eslint-disable-next-line no-sync
         fs.renameSync(logFileName, `${logFileName}.0`);
 
         logger.info('Log file rotated');

--- a/src/utils/secureCredentials.js
+++ b/src/utils/secureCredentials.js
@@ -35,7 +35,9 @@ class SecureCredentials {
 
       // Try to read from file first (most secure)
       try {
+        // eslint-disable-next-line no-sync
         if (fs.existsSync(config.file)) {
+          // eslint-disable-next-line no-sync
           value = fs.readFileSync(config.file, 'utf8').trim();
           logger.info(`Loaded ${key} from secure file: ${config.file}`);
         }

--- a/test/generate-signature.js
+++ b/test/generate-signature.js
@@ -6,6 +6,7 @@ const payloadPath = process.argv[2] || './test-payload.json';
 const webhookUrl = process.argv[3] || 'http://localhost:3001/api/webhooks/github';
 
 // Read the payload file
+// eslint-disable-next-line no-sync
 const payload = fs.readFileSync(payloadPath, 'utf8');
 
 // Calculate the signature using the utility

--- a/test/unit/utils/awsCredentialProvider.test.js
+++ b/test/unit/utils/awsCredentialProvider.test.js
@@ -2,7 +2,11 @@
 const fs = require('fs');
 
 // Mock dependencies
-jest.mock('fs');
+jest.mock('fs', () => ({
+  promises: {
+    readFile: jest.fn()
+  }
+}));
 jest.mock('../../../src/utils/logger', () => ({
   createLogger: jest.fn().mockReturnValue({
     info: jest.fn(),
@@ -45,11 +49,11 @@ region = us-west-2
     awsCredentialProvider.clearCache();
 
     // Mock file system
-    fs.readFileSync.mockImplementation(filePath => {
+    fs.promises.readFile.mockImplementation(filePath => {
       if (filePath.endsWith('credentials')) {
-        return mockCredentialsFile;
+        return Promise.resolve(mockCredentialsFile);
       } else if (filePath.endsWith('config')) {
-        return mockConfigFile;
+        return Promise.resolve(mockConfigFile);
       }
       throw new Error(`Unexpected file path: ${filePath}`);
     });
@@ -65,7 +69,7 @@ region = us-west-2
     });
 
     expect(awsCredentialProvider.credentialSource).toBe('AWS Profile (test-profile)');
-    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
+    expect(fs.promises.readFile).toHaveBeenCalledTimes(2);
   });
 
   test('should cache credentials', async () => {
@@ -73,19 +77,19 @@ region = us-west-2
     awsCredentialProvider.clearCache();
     
     // Reset mock counters
-    fs.readFileSync.mockClear();
+    fs.promises.readFile.mockClear();
     
     // First call should read from files
     const credentials1 = await awsCredentialProvider.getCredentials();
     
-    // Count how many times readFileSync was called on first request
-    const firstCallCount = fs.readFileSync.mock.calls.length;
+    // Count how many times readFile was called on first request
+    const firstCallCount = fs.promises.readFile.mock.calls.length;
     
     // Should be exactly 2 calls (credentials and config files)
     expect(firstCallCount).toBe(2);
     
     // Reset counter to clearly see calls for second request
-    fs.readFileSync.mockClear();
+    fs.promises.readFile.mockClear();
     
     // Second call should use cached credentials and not read files again
     const credentials2 = await awsCredentialProvider.getCredentials();
@@ -94,7 +98,7 @@ region = us-west-2
     expect(credentials1).toBe(credentials2);
     
     // Verify no additional file reads occurred on second call
-    expect(fs.readFileSync).not.toHaveBeenCalled();
+    expect(fs.promises.readFile).not.toHaveBeenCalled();
   });
 
   test('should clear credential cache', async () => {
@@ -104,7 +108,7 @@ region = us-west-2
 
     expect(credentials1).not.toBe(credentials2);
     // Should read files twice (once for each getCredentials call)
-    expect(fs.readFileSync).toHaveBeenCalledTimes(4);
+    expect(fs.promises.readFile).toHaveBeenCalledTimes(4);
   });
 
   test('should get Docker environment variables', async () => {
@@ -149,8 +153,8 @@ region = us-west-2
 aws_access_key_id = test-access-key
     `;
 
-    fs.readFileSync.mockImplementationOnce(() => incompleteCredentials);
-    fs.readFileSync.mockImplementationOnce(() => mockConfigFile);
+    fs.promises.readFile.mockImplementationOnce(() => Promise.resolve(incompleteCredentials));
+    fs.promises.readFile.mockImplementationOnce(() => Promise.resolve(mockConfigFile));
 
     await expect(awsCredentialProvider.getCredentials()).rejects.toThrow(
       'Incomplete credentials for profile \'test-profile\''

--- a/test/unit/utils/awsCredentialProvider.test.js
+++ b/test/unit/utils/awsCredentialProvider.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-sync */
 const fs = require('fs');
 
 // Mock dependencies


### PR DESCRIPTION
## Summary
- Resolved all 21 linter warnings related to the `no-sync` ESLint rule
- Converted async file operations where appropriate
- Added eslint-disable comments for necessary sync operations during initialization

## Changes
- **awsCredentialProvider.js**: Converted `fs.readFileSync` to `fs.promises.readFile` for async profile loading
- **logger.js**: Added eslint-disable comments for sync operations needed during startup
- **secureCredentials.js**: Added eslint-disable comments for sync credential loading during initialization
- **test files**: Added eslint-disable comments for mocked sync operations in tests

## Test plan
- [x] Run `npm run lint:check` to verify all warnings are resolved
- [ ] Run `npm test` to ensure all tests pass
- [ ] Verify service starts correctly with Docker Compose
- [ ] Test AWS credential loading functionality

🤖 Generated with [Claude Code](https://claude.ai/code)