### PR TITLE
Remove Node.js 18 from CI/CD pipeline

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x]
     
     steps:
     - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For comprehensive documentation, see:
 
 ### Prerequisites
 
-- Node.js 16 or higher
+- Node.js 20 or higher
 - Docker and Docker Compose
 - GitHub account with access to the repositories you want to use
 

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "nodemon": "^3.0.1",
     "prettier": "^3.0.0",
     "supertest": "^7.1.1"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/src/controllers/githubController.js
+++ b/src/controllers/githubController.js
@@ -2,7 +2,7 @@ const crypto = require('crypto');
 const claudeService = require('../services/claudeService');
 const githubService = require('../services/githubService');
 const { createLogger } = require('../utils/logger');
-const { sanitizeBotMentions, sanitizeLabels } = require('../utils/sanitize');
+const { sanitizeBotMentions } = require('../utils/sanitize');
 const secureCredentials = require('../utils/secureCredentials');
 
 const logger = createLogger('githubController');

--- a/src/services/claudeService.js
+++ b/src/services/claudeService.js
@@ -96,16 +96,16 @@ For real functionality, please configure valid GitHub and Claude API tokens.`;
     // Select appropriate entrypoint script based on operation type
     let entrypointScript;
     switch (operationType) {
-      case 'auto-tagging':
-        entrypointScript = '/scripts/runtime/claudecode-tagging-entrypoint.sh';
-        logger.info({ operationType }, 'Using minimal tools for auto-tagging operation');
-        break;
-      case 'pr-review':
-      case 'default':
-      default:
-        entrypointScript = '/scripts/runtime/claudecode-entrypoint.sh';
-        logger.info({ operationType }, 'Using full tool set for standard operation');
-        break;
+    case 'auto-tagging':
+      entrypointScript = '/scripts/runtime/claudecode-tagging-entrypoint.sh';
+      logger.info({ operationType }, 'Using minimal tools for auto-tagging operation');
+      break;
+    case 'pr-review':
+    case 'default':
+    default:
+      entrypointScript = '/scripts/runtime/claudecode-entrypoint.sh';
+      logger.info({ operationType }, 'Using full tool set for standard operation');
+      break;
     }
 
     // Create unique container name (sanitized to prevent command injection)


### PR DESCRIPTION
## Summary
- Removes Node.js 18.x from PR workflow test matrix to address @octokit/rest v22.0.0 compatibility
- Updates documentation to reflect Node.js 20+ requirement consistently across README and package.json
- Fixes minor linting issues discovered during the process

## Test plan
- [x] All unit tests pass on Node.js 20
- [x] Linting passes without errors
- [x] CI/CD pipeline simplified by removing Node.js 18.x builds
- [x] Documentation updated to reflect new minimum version requirement

This change addresses issue #68 by removing support for Node.js 18, which is no longer compatible with the updated @octokit/rest dependency, and ensures consistent Node.js version requirements across the project.

🤖 Generated with [Claude Code](https://claude.ai/code)