### PR TITLE
fix: update README URLs to use correct repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Claude analyzes your entire repository context, understands your codebase, and p
 
 ```bash
 # Clone and setup
-git clone https://github.com/yourusername/claude-github-webhook.git
-cd claude-github-webhook
+git clone https://github.com/intelligence-assist/claude-hub.git
+cd claude-hub
 ./scripts/setup/setup-secure-credentials.sh
 
 # Launch with Docker Compose
@@ -276,7 +276,7 @@ npm run dev
 
 ### Support
 
-- Report issues: [GitHub Issues](https://github.com/yourusername/claude-github-webhook/issues)
+- Report issues: [GitHub Issues](https://github.com/intelligence-assist/claude-hub/issues)
 - Detailed troubleshooting: [Complete Workflow Guide](./docs/complete-workflow.md#troubleshooting)
 
 ## License


### PR DESCRIPTION
## Summary

- Fixed clone URL from  to 
- Fixed issues URL to point to correct repository  
- Updated directory name in clone instructions to match repository name

## Changes Made

1. **Clone URL (line 50)**: Updated from generic placeholder to actual repository URL
2. **Issues URL (line 279)**: Fixed GitHub issues link to point to this repository
3. **Directory name**: Changed from  to  to match actual repository name

Fixes #79