### PR TITLE
docs: update codecov badge to use public URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI Pipeline](https://github.com/intelligence-assist/claude-hub/actions/workflows/ci.yml/badge.svg)](https://github.com/intelligence-assist/claude-hub/actions/workflows/ci.yml)
 [![Security Scans](https://github.com/intelligence-assist/claude-hub/actions/workflows/security.yml/badge.svg)](https://github.com/intelligence-assist/claude-hub/actions/workflows/security.yml)
 [![Jest Tests](https://img.shields.io/badge/tests-jest-green)](test/README.md)
-[![Code Coverage](https://img.shields.io/badge/coverage-59%25-yellow)](./coverage/index.html)
+[![codecov](https://codecov.io/gh/intelligence-assist/claude-hub/branch/main/graph/badge.svg)](https://codecov.io/gh/intelligence-assist/claude-hub)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](package.json)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 


### PR DESCRIPTION
## Summary
- Update codecov badge to use the public URL format without token parameter
- This change is needed since claude-hub is now a public repository

## Test plan
- [x] Verify README renders correctly with the new badge
- [x] Confirm codecov badge displays properly on GitHub

🤖 Generated with [Claude Code](https://claude.ai/code)