### PR TITLE
Fix CI pipeline jest coverage command error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
       run: npm ci --prefer-offline --no-audit
 
     - name: Generate test coverage
-      run: npx jest --coverage --testPathPattern='test/(unit|integration).*\.test\.js$'
+      run: npm run test:ci
       env:
         NODE_ENV: test
         BOT_USERNAME: '@TestBot'

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:e2e": "jest --testMatch='**/test/e2e/**/*.test.js'",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
-    "test:ci": "jest --ci --coverage",
+    "test:ci": "jest --ci --coverage --testPathPattern='test/(unit|integration).*\\.test\\.js$'",
     "pretest": "./scripts/utils/ensure-test-dirs.sh",
     "lint": "eslint src/ test/ --fix",
     "lint:check": "eslint src/ test/",


### PR DESCRIPTION
## Summary
- Fix the CI pipeline error where `jest: command not found` was occurring in the coverage generation step
- Replace direct `npx jest` call with `npm run test:ci` to ensure jest is properly available
- Update the test:ci script to match the original command pattern for unit and integration tests

## Changes Made
1. Updated `.github/workflows/ci.yml` to use `npm run test:ci` instead of `npx jest --coverage --testPathPattern=...`
2. Enhanced the `test:ci` script in `package.json` to include the specific test path pattern that was being used

## Test Plan
- [x] Verified tests run successfully locally with `npm run test:ci`
- [x] All existing unit tests pass
- [x] Linting passes
- [x] No breaking changes to existing functionality

## Fixes
Closes #91

🤖 Generated with [Claude Code](https://claude.ai/code)