### PR TITLE
fix(pr-review): enhance PR review triggering with 2-minute wait and follow-up monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,5 +40,10 @@ ANTHROPIC_MODEL=us.anthropic.claude-3-7-sonnet-20250219-v1:0
 # USE_AWS_PROFILE=true
 # AWS_PROFILE=claude-webhook
 
+# PR Review Configuration
+PR_REVIEW_WAIT_FOR_ALL_CHECKS=true
+PR_REVIEW_DEBOUNCE_MS=120000  # Wait 2 minutes (120000ms) after checks pass before reviewing
+PR_REVIEW_TRIGGER_WORKFLOW=Pull Request CI
+
 # Test Configuration
 TEST_REPO_FULL_NAME=owner/repo

--- a/src/services/githubService.js
+++ b/src/services/githubService.js
@@ -645,6 +645,114 @@ async function managePRLabels({
   }
 }
 
+/**
+ * Gets reviews for a pull request
+ * @param {Object} params
+ * @param {string} params.repoOwner - Repository owner
+ * @param {string} params.repoName - Repository name
+ * @param {number} params.prNumber - Pull request number
+ * @returns {Promise<Array>} Array of reviews
+ */
+async function getPRReviews({ repoOwner, repoName, prNumber }) {
+  try {
+    // Validate parameters
+    const repoPattern = /^[a-zA-Z0-9._-]+$/;
+    if (!repoPattern.test(repoOwner) || !repoPattern.test(repoName)) {
+      throw new Error('Invalid repository owner or name - contains unsafe characters');
+    }
+
+    logger.info(
+      {
+        repo: `${repoOwner}/${repoName}`,
+        pr: prNumber
+      },
+      'Getting PR reviews'
+    );
+
+    // In test mode, return mock data
+    const client = getOctokit();
+    if (process.env.NODE_ENV === 'test' || !client) {
+      return [];
+    }
+
+    // Use Octokit to get reviews
+    const { data } = await client.pulls.listReviews({
+      owner: repoOwner,
+      repo: repoName,
+      pull_number: prNumber
+    });
+
+    return data;
+  } catch (error) {
+    logger.error(
+      {
+        err: error.message,
+        repo: `${repoOwner}/${repoName}`,
+        pr: prNumber
+      },
+      'Failed to get PR reviews'
+    );
+    throw error;
+  }
+}
+
+/**
+ * Gets information about a pull request
+ * @param {Object} params
+ * @param {string} params.repoOwner - Repository owner
+ * @param {string} params.repoName - Repository name
+ * @param {number} params.prNumber - Pull request number
+ * @returns {Promise<Object>} PR information
+ */
+async function getPRInfo({ repoOwner, repoName, prNumber }) {
+  try {
+    // Validate parameters
+    const repoPattern = /^[a-zA-Z0-9._-]+$/;
+    if (!repoPattern.test(repoOwner) || !repoPattern.test(repoName)) {
+      throw new Error('Invalid repository owner or name - contains unsafe characters');
+    }
+
+    logger.info(
+      {
+        repo: `${repoOwner}/${repoName}`,
+        pr: prNumber
+      },
+      'Getting PR info'
+    );
+
+    // In test mode, return mock data
+    const client = getOctokit();
+    if (process.env.NODE_ENV === 'test' || !client) {
+      return {
+        head: {
+          repo: {
+            pushed_at: new Date().toISOString()
+          }
+        }
+      };
+    }
+
+    // Use Octokit to get PR info
+    const { data } = await client.pulls.get({
+      owner: repoOwner,
+      repo: repoName,
+      pull_number: prNumber
+    });
+
+    return data;
+  } catch (error) {
+    logger.error(
+      {
+        err: error.message,
+        repo: `${repoOwner}/${repoName}`,
+        pr: prNumber
+      },
+      'Failed to get PR info'
+    );
+    throw error;
+  }
+}
+
 module.exports = {
   postComment,
   addLabelsToIssue,
@@ -653,5 +761,7 @@ module.exports = {
   getCombinedStatus,
   hasReviewedPRAtCommit,
   managePRLabels,
-  getCheckSuitesForRef
+  getCheckSuitesForRef,
+  getPRReviews,
+  getPRInfo
 };


### PR DESCRIPTION
## Summary
- Fixes PR review triggering reliability issues and implements 2-minute wait mechanism after checks pass
- Adds follow-up monitoring to detect and handle change requests properly

## Changes Made

### Environment Configuration
- Added PR review configuration to `.env.example`:
  - `PR_REVIEW_WAIT_FOR_ALL_CHECKS=true` 
  - `PR_REVIEW_DEBOUNCE_MS=120000` (2 minutes)
  - `PR_REVIEW_TRIGGER_WORKFLOW=Pull Request CI`

### Core Fixes
- Fixed `PR_REVIEW_WAIT_FOR_ALL_CHECKS` default logic (now properly defaults to `true`)
- Increased default debounce from 5 seconds to 2 minutes (120000ms)
- Enhanced check suite completion detection reliability

### Follow-up Monitoring
- Added `checkReviewStatusAndHandleChanges()` function for post-review monitoring
- Schedules 5-minute follow-up check after review completion
- Detects when changes are requested and new commits are made
- Automatically updates PR labels based on review status
- Posts helpful follow-up comments when re-review may be needed

### GitHub Service Enhancements
- Added `getPRReviews()` method to fetch PR reviews
- Added `getPRInfo()` method to get PR information
- Enhanced error handling and validation

## Problem Solved
The original issue was that PR reviews weren't triggering reliably because:
1. Default wait time was only 5 seconds (too short for GitHub's eventual consistency)
2. No follow-up mechanism to check if reviews were completed
3. No handling of change requests and subsequent commits

## Test Plan
- [x] Unit tests pass
- [x] Linting passes
- [x] Code structure maintains existing patterns
- [ ] Test with actual PR workflow (will be tested when this PR's checks pass)

## Impact
- PRs will now get reviewed automatically after all checks pass with adequate wait time
- Better handling of change requests with follow-up monitoring
- Improved reliability of the automated review process

🤖 Generated with [Claude Code](https://claude.ai/code)