### PR TITLE
fix: correct Claude Code image name in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ ANTHROPIC_API_KEY=your_anthropic_api_key_here
 
 # Container Settings
 CLAUDE_USE_CONTAINERS=1
-CLAUDE_CONTAINER_IMAGE=claude-code-runner:latest
+CLAUDE_CONTAINER_IMAGE=claudecode:latest
 REPO_CACHE_DIR=/tmp/repo-cache
 REPO_CACHE_MAX_AGE_MS=3600000
 CONTAINER_LIFETIME_MS=7200000  # Container execution timeout in milliseconds (default: 2 hours)


### PR DESCRIPTION
## Summary
- Fixed incorrect Docker image name in .env.example file
- Changed `CLAUDE_CONTAINER_IMAGE` from `claude-code-runner:latest` to `claudecode:latest`
- This aligns with the correct image name used in docker-compose.yml

## Details
The .env.example file had an incorrect Docker image name with a `-runner` suffix that shouldn't be there. This could cause confusion for users setting up their environment.

## Test plan
- [x] Verified the correct image name matches docker-compose.yml
- [x] Updated .env.example to use the correct image name

Fixes #116

🤖 Generated with [Claude Code](https://claude.ai/code)