### PR TITLE
fix: add nightly tag for main branch Docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,7 +51,10 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            # Latest tag for version tags
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            # Nightly tag for main branch pushes
+            type=raw,value=nightly,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -106,9 +109,13 @@ jobs:
         with:
           images: ${{ env.DOCKER_HUB_ORGANIZATION }}/claudecode
           tags: |
-            type=ref,event=branch,suffix=-staging
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            # Latest tag for version tags
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            # Nightly tag for main branch pushes
+            type=raw,value=nightly,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push Claude Code Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary
- Fix the "tag is needed when pushing to registry" error in Docker publish workflow
- Add `:nightly` tag for main branch pushes
- Ensure `:latest` tag is only applied to version tags

## Changes
- Added `:nightly` tag that activates when pushing to the main branch
- Kept `:latest` tag exclusive to version tags (v*.*.*)
- Enhanced claudecode image with full semantic versioning support
- Removed the `-staging` suffix approach from claudecode image

## Test plan
- Push to main branch → Images tagged with `:nightly`
- Create version tag (e.g., v1.0.0) → Images tagged with `:latest`, `:1.0.0`, `:1.0`, `:1`
- Workflow will always have at least one valid tag to push

🤖 Generated with [Claude Code](https://claude.ai/code)