### PR TITLE
fix: correct runner labels syntax in docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   build:
     # Use self-hosted runners by default, with ability to override via repository variable
-    runs-on: ${{ fromJSON(format('["{0}"]', (vars.USE_SELF_HOSTED == 'false' && 'ubuntu-latest' || 'self-hosted, linux, x64, docker'))) }}
+    runs-on: ${{ vars.USE_SELF_HOSTED == 'false' && 'ubuntu-latest' || fromJSON('["self-hosted", "linux", "x64", "docker"]') }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -110,7 +110,7 @@ jobs:
 
   # Build claudecode separately
   build-claudecode:
-    runs-on: ${{ fromJSON(format('["{0}"]', (vars.USE_SELF_HOSTED == 'false' && 'ubuntu-latest' || 'self-hosted, linux, x64, docker'))) }}
+    runs-on: ${{ vars.USE_SELF_HOSTED == 'false' && 'ubuntu-latest' || fromJSON('["self-hosted", "linux", "x64", "docker"]') }}
     if: github.event_name != 'pull_request'
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Summary
- Fix incorrect runner labels syntax that was causing jobs to queue indefinitely
- Change from single string to proper array of individual labels

## Problem
The workflow was using:
```yaml
runs-on: ${{ fromJSON(format('["{0}"]', (vars.USE_SELF_HOSTED == 'false' && 'ubuntu-latest' || 'self-hosted, linux, x64, docker'))) }}
```

This created `["self-hosted, linux, x64, docker"]` - a single string element, when GitHub expects individual labels like `["self-hosted", "linux", "x64", "docker"]`.

## Solution
Updated to:
```yaml
runs-on: ${{ vars.USE_SELF_HOSTED == 'false' && 'ubuntu-latest' || fromJSON('["self-hosted", "linux", "x64", "docker"]') }}
```

This properly creates an array of individual labels that matches the runner configuration.

## Test plan
- [x] Verify syntax creates proper array of labels
- [ ] Confirm queued jobs start running after merge
- [ ] Test that `USE_SELF_HOSTED=false` still uses `ubuntu-latest`

🤖 Generated with [Claude Code](https://claude.ai/code)