### PR TITLE
fix: correct Claude authentication command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ Use your existing Claude Max subscription for automation instead of pay-per-use 
 ./scripts/setup/setup-claude-interactive.sh
 
 # 2. In container: authenticate with your subscription
-claude login  # Follow browser flow
-exit          # Save authentication
+claude --dangerously-skip-permissions  # Follow authentication flow
+exit                                    # Save authentication
 
 # 3. Use captured authentication  
 cp -r ${CLAUDE_HUB_DIR:-~/.claude-hub}/* ~/.claude/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-github-webhook",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A webhook endpoint for Claude to perform git and GitHub actions",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
Fixed incorrect authentication command in README.md

## Changes
- Replace non-existent `claude login` command with correct `claude --dangerously-skip-permissions`
- Update authentication flow instructions to use proper command that allows unattended runs

## Details
The `claude login` command doesn't exist. Users should use `claude --dangerously-skip-permissions` to authenticate and enable unattended automation runs.

🤖 Generated with [Claude Code](https://claude.ai/code)